### PR TITLE
Check frontend for errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,6 @@ set(SOURCES
     src/datapoller.cpp
     src/portfoliomodel.cpp
     src/ordersmodel.cpp
-    src/statusmodel.cpp
     src/notificationsmodel.cpp
 )
 
@@ -56,6 +55,7 @@ qt_add_qml_module(QtTradeFrontend
         qml/components/SideNav.qml
         qml/components/MarketList.qml
         qml/components/StatusBadge.qml
+        qml/components/CandleChart.qml
 )
 
 target_include_directories(QtTradeFrontend PRIVATE ${HIREDIS_INCLUDE_DIR})

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -1,6 +1,7 @@
 import QtQuick 2.15
 import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.15
+import Qt5Compat.GraphicalEffects 1.0
 import Frontend 1.0
 
 ApplicationWindow {

--- a/qml/components/CandleChart.qml
+++ b/qml/components/CandleChart.qml
@@ -1,6 +1,7 @@
 import QtQuick 2.15
 import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.15
+import QtQuick.Window 2.15
 import Frontend 1.0
 
 /*
@@ -19,6 +20,7 @@ Item {
     property int maxCandles: 120
     property string currentTicker: poller ? poller.currentSymbol : "AAPL"
     property bool useMock: candles.length === 0
+    property real forecastOpacity: 0.7
 
     // Neue Properties für echte Modelle
     property var modelCandles: chartDataModel // ChartDataModel aus Context

--- a/src/statusmodel.cpp
+++ b/src/statusmodel.cpp
@@ -1,0 +1,4 @@
+#include "statusmodel.h"
+
+// StatusModel is implemented entirely in the header file
+// This file exists only to satisfy the build system


### PR DESCRIPTION
Fixes frontend build and QML runtime errors by correcting CMake configuration, adding missing QML imports, and defining an undefined QML property.

---
<a href="https://cursor.com/background-agent?bcId=bc-843bd667-3439-4cff-9e73-bf5ea0d6d087">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-843bd667-3439-4cff-9e73-bf5ea0d6d087">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

