### PR TITLE
Check and fix repository errors

### DIFF
--- a/pubsub.txt
+++ b/pubsub.txt
@@ -5,7 +5,7 @@
 
 ## Überblick
 Aktuelles Setup:
-- Lokaler Redis-Slave (127.0.0.1:6380) repliziert von Remote Redis (<server-ip>:6379, Passwort: pass123).
+- Lokaler Redis-Slave (127.0.0.1:6380) repliziert von Remote Redis (<server-ip>:6380, Passwort: pass123).
 - Frontend (Qt Quick/C++) pollt Keys wie `market_data`, `chart_data_<SYMBOL>`, `predictions_<SYMBOL>` alle 5s mit exponentiellem Backoff (5s→30s).
 - Backend schreibt atomar in Redis-Keys (siehe Schema v1.1).
 

--- a/redis.txt
+++ b/redis.txt
@@ -271,7 +271,7 @@ Key: notification_settings
 ----------------------------------------------
 ## 21. Verbindung (Deployment Hinweis – nicht im Code auslesen!)
 Host: <server-ip>
-Port: 6379
+Port: 6380
 Passwort: pass123
 
 Security Hinweis: Zugangsdaten nicht im Repo in Klartext halten – env / secrets nutzen.


### PR DESCRIPTION
Update Redis port in documentation to ensure consistency with the code's default port (6380).

---
<a href="https://cursor.com/background-agent?bcId=bc-c1b10cfa-b3e7-4cb3-86e1-a68b1328b300">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c1b10cfa-b3e7-4cb3-86e1-a68b1328b300">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

